### PR TITLE
Feature/score confirmation

### DIFF
--- a/src/main/java/com/gruzini/tennistico/bootstrap/ArchivedMatchesPageDataInitialization.java
+++ b/src/main/java/com/gruzini/tennistico/bootstrap/ArchivedMatchesPageDataInitialization.java
@@ -72,7 +72,7 @@ public class ArchivedMatchesPageDataInitialization implements CommandLineRunner 
               .build();
 
       final Match match3 = Match.builder()
-              .endingAt(LocalDateTime.of(2020, Month.JUNE, 5, 12, 10))
+              .endingAt(LocalDateTime.of(2020, Month.JUNE, 12, 12, 10))
               .court(court)
               .matchStatus(MatchStatus.SCORE_TO_BE_CONFIRMED)
               .score("3-2")

--- a/src/main/java/com/gruzini/tennistico/controllers/ConfirmScoreController.java
+++ b/src/main/java/com/gruzini/tennistico/controllers/ConfirmScoreController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.security.Principal;
 
 @Controller
-@RequestMapping("/confirm-score")
+@RequestMapping("/dashboard/confirm-score")
 public class ConfirmScoreController {
 
    private final ConfirmScoreService confirmScoreService;

--- a/src/main/java/com/gruzini/tennistico/controllers/ConfirmScoreController.java
+++ b/src/main/java/com/gruzini/tennistico/controllers/ConfirmScoreController.java
@@ -1,0 +1,27 @@
+package com.gruzini.tennistico.controllers;
+
+import com.gruzini.tennistico.services.ConfirmScoreService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.security.Principal;
+
+@Controller
+@RequestMapping("/confirm-score")
+public class ConfirmScoreController {
+
+   private final ConfirmScoreService confirmScoreService;
+
+   public ConfirmScoreController(final ConfirmScoreService confirmScoreService) {
+      this.confirmScoreService = confirmScoreService;
+   }
+
+   @GetMapping("/{match_id}")
+   public String confirmScoreSetByHost(@PathVariable(name = "match_id")final Long matchId,
+                                       final Principal principal){
+      confirmScoreService.confirmScore(matchId, principal.getName());
+      return "dashboard";
+   }
+}

--- a/src/main/java/com/gruzini/tennistico/exceptions/NoGuestInMatchException.java
+++ b/src/main/java/com/gruzini/tennistico/exceptions/NoGuestInMatchException.java
@@ -1,0 +1,4 @@
+package com.gruzini.tennistico.exceptions;
+
+public class NoGuestInMatchException extends RuntimeException{
+}

--- a/src/main/java/com/gruzini/tennistico/exceptions/PlayerIsNotMatchGuestException.java
+++ b/src/main/java/com/gruzini/tennistico/exceptions/PlayerIsNotMatchGuestException.java
@@ -1,0 +1,4 @@
+package com.gruzini.tennistico.exceptions;
+
+public class PlayerIsNotMatchGuestException extends RuntimeException {
+}

--- a/src/main/java/com/gruzini/tennistico/services/ConfirmScoreService.java
+++ b/src/main/java/com/gruzini/tennistico/services/ConfirmScoreService.java
@@ -1,0 +1,46 @@
+package com.gruzini.tennistico.services;
+
+import com.gruzini.tennistico.domain.Match;
+import com.gruzini.tennistico.domain.Player;
+import com.gruzini.tennistico.domain.enums.MatchStatus;
+import com.gruzini.tennistico.exceptions.NoGuestInMatchException;
+import com.gruzini.tennistico.exceptions.PlayerIsNotMatchGuestException;
+import com.gruzini.tennistico.exceptions.WrongMatchStatusException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConfirmScoreService {
+   private final PlayerService playerService;
+   private final MatchService matchService;
+
+   public ConfirmScoreService(final PlayerService playerService,
+                              final MatchService matchService) {
+      this.playerService = playerService;
+      this.matchService = matchService;
+   }
+
+   public void confirmScore(final Long matchId, final String username) {
+      final Player player = playerService.getByUsername(username);
+      final Match match = matchService.getById(matchId);
+      validateMatchAndPlayer(match, player);
+      matchService.updateMatchStatus(match, MatchStatus.ARCHIVED);
+   }
+
+   private void validateMatchAndPlayer(final Match match, final Player player) {
+      validateMatchStatus(match);
+      validateMatchGuest(match, player);
+   }
+
+   private void validateMatchStatus(final Match match) {
+      if(!match.getMatchStatus().equals(MatchStatus.SCORE_TO_BE_CONFIRMED)){
+         throw new WrongMatchStatusException();
+      }
+   }
+
+   private void validateMatchGuest(final Match match, final Player player) {
+      final Player guest = match.getGuest().orElseThrow(NoGuestInMatchException::new);
+      if(!guest.equals(player)){
+         throw new PlayerIsNotMatchGuestException();
+      }
+   }
+}


### PR DESCRIPTION
Created endpoint for confirming score by guest.
Throws exceptions if for some reason match has no guest, has wrong Status (in special occasion when cleaner already changed status to BUSTED), also when player trynig to confirm score isn't a guest.