### PR TITLE
always redirecting to dashboard after login

### DIFF
--- a/src/main/java/com/gruzini/tennistico/security/SecurityConfig.java
+++ b/src/main/java/com/gruzini/tennistico/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .loginPage("/login")
                 .usernameParameter("username")
                 .passwordParameter("password")
-                .defaultSuccessUrl("/dashboard")
+                .defaultSuccessUrl("/dashboard", true)
                 .failureUrl("/login-error");
 
         http.logout();


### PR DESCRIPTION
Prosta poprawka, ustawienie redirectu na dashboard po logowaniu, w przeciwnym wypadku powodowało to problemy z ustawieniem nazwy użytkownika i rankingu w navbarze (logika siedzi w DashboardControllerze)